### PR TITLE
Fix images might not be present at app startup

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -1,10 +1,10 @@
 const { contextBridge, ipcRenderer } = require('electron');
 const logToFile = require('./logger');
+const fs = require('fs');
 
 contextBridge.exposeInMainWorld('electron', {
-  readDir: async (path) => {
-    return await ipcRenderer.invoke('read-dir', path);
-  },
+  readDir: (path) => ipcRenderer.invoke('read-dir', path),
+  exists: (path) => fs.existsSync(path),
   currentDir: __dirname,
   logToFile
 });

--- a/scheduler.js
+++ b/scheduler.js
@@ -4,22 +4,25 @@ const fs = require('fs');
 const path = require('path');
 const logToFile = require('./logger');
 
-const todaysDate = new Date().toISOString().split('T')[0];
-const subfolder = 'memes-archive';
-const imagesFolderPath = path.join(__dirname, subfolder, todaysDate);
+async function verifyTodaysImages() {
+  const todaysDate = new Date().toISOString().split('T')[0];
+  const subfolder = 'memes-archive';
+  const imagesFolderPath = path.join(__dirname, subfolder, todaysDate);
 
-// check for memes-archive subfolder, make if not present
-if (!fs.existsSync(path.join(__dirname, subfolder))) {
-  logToFile('made memes-archive folder')
-  fs.mkdirSync(path.join(__dirname, subfolder));
-}
-// check for today's dated images folder, make if not present
-if (!fs.existsSync(imagesFolderPath)) {
-  logToFile('made todays memes images folder')
-  fs.mkdirSync(imagesFolderPath);
-  // since we just made the folder, we need to run the script to download the images for today (since it won't exist yet)
-  logToFile('today\'s memes images folder didn\'t exist yet, running script to download images');
-  runScript();
+  // check for memes-archive subfolder, make if not present
+  if (!fs.existsSync(path.join(__dirname, subfolder))) {
+    logToFile('made memes-archive folder')
+    fs.mkdirSync(path.join(__dirname, subfolder));
+  }
+
+  // check for today's dated images folder, make if not present
+  if (!fs.existsSync(imagesFolderPath)) {
+    logToFile('made todays memes images folder')
+    fs.mkdirSync(imagesFolderPath);
+    // since we just made the folder, we need to run the script to download the images for today (since it won't exist yet)
+    logToFile('today\'s memes images folder didn\'t exist yet, running script to download images');
+    await runScript();
+  }
 }
 
 logToFile('Job scheduler for updating images is activated!');
@@ -30,28 +33,37 @@ cron.schedule('0 8 * * *', () => {
   runScript();
 });
 
-function runScript(){
-  logToFile('Running download-todays-memes.js script...');
+function runScript() {
+  return new Promise((resolve, reject) => {
+    logToFile('Running download-todays-memes.js script...');
 
-  // Execute the download-todays-memes.js script
-  const script = spawn('node', ['./download-todays-memes.js']);
+    // Execute the download-todays-memes.js script
+    const script = spawn('node', ['./download-todays-memes.js']);
 
-  // Log the script's output
-  script.stdout.on('data', (data) => {
-    // trim the newline character from the end
-    data = data.toString().trim();
-    logToFile(data);
-  });
+    // Log the script's output
+    script.stdout.on('data', (data) => {
+      // trim the newline character from the end
+      data = data.toString().trim();
+      logToFile(data);
+    });
 
-  // Log any errors
-  script.stderr.on('data', (data) => {
-    // trim the newline character from the end
-    data = data.toString().trim();
-    logToFile(`Error: ${data}`);
-  });
+    // Log any errors
+    script.stderr.on('data', (data) => {
+      // trim the newline character from the end
+      data = data.toString().trim();
+      logToFile(`Error: ${data}`);
+    });
 
-  // Log when the script is done running
-  script.on('close', (code) => {
-    logToFile(`Memes download script exited with code ${code} (${(code) ? 'There were errors' : 'No errors'})`);
+    // Log when the script is done running
+    script.on('close', (code) => {
+      logToFile(`Memes download script exited with code ${code} (${(code) ? 'There were errors' : 'No errors'})`);
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(`Script exited with code ${code}`);
+      }
+    });
   });
 }
+
+module.exports = verifyTodaysImages;

--- a/splash.html
+++ b/splash.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <style>
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      background-color: #282c34;
+      color: white;
+    }
+
+    .loader-container {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      flex-direction: column;
+      height: 100vh;
+      width: 100vw;
+      position: absolute;
+      top: 0;
+      left: 0;
+      font-family: 'Arial', sans-serif;
+    }
+
+    .loader {
+      border: 16px solid #f3f3f3;
+      border-top: 16px solid #3498db;
+      border-radius: 50%;
+      width: 120px;
+      height: 120px;
+      animation: spin 2s linear infinite;
+    }
+
+    .loading-text {
+      margin-top: 20px;
+      font-size: 24px;
+      font-weight: bold;
+      color: white;
+      text-align: center;
+    }
+
+    @keyframes spin {
+      0% {
+        transform: rotate(0deg);
+      }
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div class="loader-container">
+    <div class="loader"></div>
+    <p class="loading-text">Downloading today's memes, please wait...</p>
+  </div>
+</body>
+
+
+</html>


### PR DESCRIPTION
This fixes #3 

This adds logic to download images and create directories PRIOR to the main app window opening and images attempting to be loaded. This makes sure the app always loads correctly and that images are ready before it attempts to load them. This mainly affects first-runs of the app and runs where it hasn't been ran for over a day (directories missing for current day).

This also adds a splash screen that shows the user that this is happening and to wait a moment, rather than sitting on a blank screen.